### PR TITLE
Migrate Docker frontend build from npm to pnpm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Mirrors most of .gitignore but is consumed by Docker's build context
+# loader. Keeping host-only state out of the context avoids two problems:
+#   1. BuildKit fails to checksum broken/host-rooted symlinks (e.g. a
+#      Python venv's interpreter symlink points at /opt/homebrew/...)
+#   2. Sending node_modules / .git / build outputs to the daemon makes
+#      builds slow and bloats layer caches.
+
+# Git
+.git
+.gitignore
+
+# OS / editor
+.DS_Store
+**/.DS_Store
+.vscode
+.idea
+
+# Python (local dev artifacts)
+**/__pycache__
+**/*.pyc
+**/venv
+**/.venv
+
+# Node (regenerated inside the container by pnpm install)
+node_modules
+.next
+out
+
+# Logs
+*.log
+
+# Local notes / scratch (not part of the project)
+design-brief.md

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ build/Release
 node_modules/
 jspm_packages/
 
+# pnpm lockfile (intentionally not committed; generated during docker build)
+pnpm-lock.yaml
+
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/
 
@@ -131,6 +134,10 @@ dist
 
 # python
 __pycache__
+
+# python virtualenvs (local dev)
+venv/
+.venv/
 
 # flask
 flask_session

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-
+# syntax=docker/dockerfile:1.7-labs
+# Parser directive above must remain on line 1. The 1.7-labs frontend
+# enables the COPY --exclude flag used when copying ./server/ below.
 
 # Build our Java app
 FROM node:current-alpine AS java-build
@@ -18,14 +20,17 @@ FROM node:current-alpine AS frontend-build
 
 WORKDIR /buildsite
 
-# Install needed tools (won't have an impact if everything is all set)
-RUN apk add --no-cache npm nodejs && \
-    npm update -g npm
+# Install pnpm. Keep this version in sync with the "packageManager" field in
+# package.json so local and container builds resolve the same dependency tree.
+RUN npm install -g pnpm@10.20.0
 
-# Install the package dependencies
+# Install dependencies. The lockfile is intentionally not committed to source
+# control (per project policy), so pnpm resolves and writes pnpm-lock.yaml
+# fresh during the build. The generated lockfile is copied into the final
+# image (see below) so it can be inspected for debugging a specific build.
 COPY ./package.json ./
 
-RUN npm install
+RUN pnpm install
 
 # Copy other files where we want them
 COPY ./next.config.js ./
@@ -33,7 +38,7 @@ COPY ./public ./public
 COPY ./app ./app
 
 # Build the node packages
-RUN npm run build
+RUN pnpm run build
 
 
 # Build the final image
@@ -80,12 +85,20 @@ COPY --from=java-build /javasite/target/ExifWriter-1.0-jar-with-dependencies.jar
 # Copy over the built website
 COPY --from=frontend-build /buildsite/out ./
 
+# Copy the lockfile that pnpm generated during the frontend build so the
+# exact versions of every transitive dependency that went into this image
+# are inspectable for debugging.
+COPY --from=frontend-build /buildsite/pnpm-lock.yaml ./pnpm-lock.yaml
+
 # Copy the source code over
 COPY --exclude=__pycache__ --exclude=.DS_Store ./server/ ./
 
+# Set up runtime state. `rm -f *.sqlite` uses -f so the build does not fail
+# when the source tree has no checked-in .sqlite file (the *.sqlite glob is
+# in .gitignore, so a clean clone won't have one).
 RUN mkdir templates && \
     mv index.html templates/ && \
-    rm *.sqlite    && \
+    rm -f *.sqlite && \
     python3 create_db.py $PWD sparcd.sqlite && \
     rm create_db.py && \
     rm -f requirements.txt .DS_Store

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint": "^10.0.2",
     "eslint-config-next": "^16.1.6",
     "next": "^16.1.6",
+    "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-timezone-select": "^3.2.8",
@@ -32,5 +33,6 @@
   },
   "devDependencies": {
     "resize-observer-polyfill": "^1.5.1"
-  }
+  },
+  "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd"
 }


### PR DESCRIPTION
Switches the Docker frontend build from npm to pnpm. Pins pnpm 10.20.0 in `package.json`. The lockfile is not committed (per project policy from discussion below) — pnpm generates it during the build, and the Dockerfile copies the generated lockfile into the final image at `/website/pnpm-lock.yaml` so the exact versions used in a given build are inspectable for debugging.

Also adds a `.dockerignore`. Without it the build fails on any machine that has `server/venv/` locally, because BuildKit can't checksum the venv's symlinks into `/opt/homebrew/...`.

Small things along the way: `prop-types` was being pulled in transitively but is imported directly in a few components, so I added it to `dependencies`. Changed `rm *.sqlite` to `rm -f` so the build doesn't fail on a clean clone.

Tested with `docker build -t sparcd-web:test .` from a clean tree, and confirmed `/website/pnpm-lock.yaml` exists in the final image.