### PR TITLE
Improve frontend color contrast

### DIFF
--- a/app/CollectionsManage.js
+++ b/app/CollectionsManage.js
@@ -482,7 +482,7 @@ export default function CollectionsManage({loadingCollections, selectedCollectio
       <Grid id='collection-manage-workspace' container direction='row' alignItems='start' justifyContent='start' sx={{ width:'100vw' }} columns={48}>
         <div id='collection-manage-workspace-collections-wrapper' 
                 style={{minWidth:'calc(100vw - 460px)', maxWidth:'calc(100vw - 460px)', maxHeight:curHeight, paddingLeft:'10px', overflowY:'scroll'}}>
-          <Grid id='collection-manage-workspace-collections-details' container direction="row" >
+          <Grid id='collection-manage-workspace-collections-details' container direction="row" sx={{gap:'12px'}} >
             { collectionsItems && collectionsItems.map((item, idx) =>
               <Grid key={'collection-'+item.name+'-'+idx} >
                     <Grid display='flex' justifyContent='left' size='grow' >
@@ -490,14 +490,22 @@ export default function CollectionsManage({loadingCollections, selectedCollectio
                             onClick={(event) => onCollectionChange(event, item.bucket, item.id)}
                             variant="outlined"
                             data-active={selectionIndex === idx ? '' : undefined}
-                            sx={{border:'2px solid rgba(128, 128, 185, 0.5)', borderRadius:'15px', minWidth:'400px', maxWidth:'400px',
-                                  backgroundColor:'rgba(218, 232,242,0.7)',
-                                  '&[data-active]': {borderColor:'rgba(155, 175, 202, 0.85)'},
-                                  '&:hover':{backgroundColor:'rgba(185, 185, 185, 0.25)'}
+                            sx={{border:'1px solid', borderColor:'#7f8c96', borderRadius:'6px', minWidth:'400px', maxWidth:'400px',
+                                  backgroundColor:'#f6f7f8',
+                                  color:'text.primary',
+                                  '&[data-active]': {borderColor:'#4f6274', backgroundColor:'#e8ecef'},
+                                  '&:hover':{backgroundColor:'#eeeeee'}
                                 }}
                       >
                         <CardActionArea data-active={selectionIndex === idx ? '' : undefined}
-                          sx={{height: '100%',  '&[data-active]': {backgroundColor:'rgba(64, 64, 64, 0.23)'} }}
+                          sx={{height: '100%',
+                               color:'inherit',
+                               '&[data-active]': {backgroundColor:'transparent'},
+                               '&.Mui-focusVisible': {
+                                 outline:'2px solid #1565c0',
+                                 outlineOffset:'-2px',
+                               },
+                          }}
                         >
                           <CardContent>
                             <Grid container direction="column" spacing={1}>
@@ -543,7 +551,7 @@ export default function CollectionsManage({loadingCollections, selectedCollectio
           </Grid>
         </div>
         <div id='collection-manage-workspace-uploads-wrapper' style={{minWidth:'460px', maxWidth:'460px', maxHeight:curHeight, paddingRight:'10px', overflowY:"scroll"}}>
-          <Grid id='collection-manage-workspace-uploads-details' container direction="column" alignItems='start' justifyContent="start">
+          <Grid id='collection-manage-workspace-uploads-details' container direction="column" alignItems='start' justifyContent="start" sx={{gap:'8px'}}>
             { filteredUploads && 
               <Grid container direction="row" alignItems="center" justifyContent="flex-end"
                     onClick={uploadFiltering ? null : handlesUploadFiltering}

--- a/app/Login.js
+++ b/app/Login.js
@@ -200,8 +200,9 @@ export default function Login({prevUrl, prevUser, prevRemember, onLogin, onRemem
                     </FormGroup>
 
             <div style={{...theme.palette.login_dialog_login_button_wrap}}>
-              <Button size='small' color='login_button'
-                      sx={{bgcolor: 'background.default', '&:hover':{backgroundColor:'#AEAEAE'}}} endIcon={<LoginIcon />} 
+              <Button size='small' variant='contained' color='login_button'
+                      sx={{boxShadow:'none', '&:hover':{boxShadow:'none'}}}
+                      endIcon={<LoginIcon />} 
                       onClick={callLoginFunc}
               >
                 Login

--- a/app/Theme.js
+++ b/app/Theme.js
@@ -1,7 +1,20 @@
 /** @module theme */
 
 import { createTheme } from '@mui/material/styles';
-import { grey } from '@mui/material/colors';
+
+const appColors = {
+  page: '#f4f7fa',
+  surface: '#ffffff',
+  surfaceMuted: '#edf3f7',
+  surfaceTint: '#dcebf3',
+  surfaceTintAlt: '#cbd7e2',
+  border: '#6f7d89',
+  borderSubtle: '#aeb9c3',
+  text: '#17212b',
+  textMuted: '#4b5d6d',
+  darkOverlay: 'rgba(10, 18, 28, 0.72)',
+  darkPanel: 'rgba(14, 23, 33, 0.92)',
+};
 
 /** The working theme */
 let theme = createTheme({
@@ -12,9 +25,14 @@ let theme = createTheme({
   },
   palette: {
     background: {
-      default: grey[500],
-      paper: grey[500],
+      default: appColors.page,
+      paper: appColors.surface,
     },
+    text: {
+      primary: appColors.text,
+      secondary: appColors.textMuted,
+    },
+    divider: appColors.borderSubtle,
     main: {
       position: 'relative',
       display: 'flex',
@@ -22,8 +40,9 @@ let theme = createTheme({
       justifyContent: 'space-between',
       alignItems: 'flex-start',
       minHeight: '100vh',
-      backgroundColor: '#EFEFEF',
+      backgroundColor: appColors.page,
       background: 'linear-gradient(135deg, #3b5a7d 0%, #9bbdd9 50%, #7a9bc4 100%)',
+      color: appColors.text,
     },
     title_bar: {
       width: '100vw',
@@ -32,9 +51,10 @@ let theme = createTheme({
       flexDirection: 'row',
       justifyContent: 'left',
       alignItems: 'center',
-      borderBottom: '1px solid black',
-      boxShadow: '2px 3px 3px #bbbbbb',
-      backgroundColor: 'white',
+      borderBottom: `1px solid ${appColors.border}`,
+      boxShadow: '0 2px 5px rgba(23, 33, 43, 0.18)',
+      backgroundColor: appColors.surface,
+      color: appColors.text,
     },
     footer_bar: {
       width: '100vw',
@@ -43,8 +63,9 @@ let theme = createTheme({
       justifyContent: 'space-between',
       alignItems: 'center',
       padding: '5px 5px 5px 5px',
-      borderTop: '1px solid gray',
-      backgroundColor: 'white',
+      borderTop: `1px solid ${appColors.border}`,
+      backgroundColor: appColors.surface,
+      color: appColors.text,
     },
     footer_wrapper: {
       display: 'flex',
@@ -66,10 +87,10 @@ let theme = createTheme({
       maxWidth: '33%',
     },
     footer_outside_link: {
-      color: 'blue',
+      color: '#124f8f',
       fontSize: '6pt',
       fontWeight: 'bold',
-      border: '1px solid black',
+      border: `1px solid ${appColors.border}`,
       borderRadius: '3px',
       padding: '0px 2px',
     },
@@ -86,9 +107,10 @@ let theme = createTheme({
       gridColumn: 2,
       gridRow: 2,
       width: '338px',
-      border: '2px solid white',
+      border: `2px solid ${appColors.surface}`,
       borderRadius: '20px',
-      backgroundColor: 'rgba(200, 200, 200, 0.50)',
+      backgroundColor: 'rgba(244, 247, 250, 0.88)',
+      color: appColors.text,
     },
     login_dialog: {
     },
@@ -103,20 +125,21 @@ let theme = createTheme({
       left: 0,
       width: '100vw',
       height: '100vh',
-      backgroundColor: 'rgb(0,0,0,0.5)',
+      backgroundColor: appColors.darkOverlay,
       zIndex: 11111,
     },
     login_checking: {
-      backgroundColor: 'rgb(0,0,0,0.8)',
-      border: '1px solid grey',
+      backgroundColor: appColors.darkPanel,
+      border: `1px solid ${appColors.borderSubtle}`,
       borderRadius: '15px',
       padding: '25px 10px',
+      color: appColors.surface,
     },
     login_button: {
-      main: '#EFEFEF',
-      light: '#FFFFFF',
-      dark: '#E0E0E0',
-      contrastText: '#000000',
+      main: '#1565c0',
+      light: '#2d7dd2',
+      dark: '#0d47a1',
+      contrastText: appColors.surface,
     },
     login_dialog_login_button_wrap: {
       marginRight: '10px',
@@ -133,14 +156,15 @@ let theme = createTheme({
       left: '0px',
     },
     landing_card: {
-      backgroundColor: 'rgba(255, 255, 255, 0.78)',
+      backgroundColor: 'rgba(255, 255, 255, 0.9)',
       borderRadius: '15px',
       minHeight: '15vh',
       minWidth: '46vw',
       maxWidth: '46vw',
+      color: appColors.text,
     },
     landing_upload: {
-      border: '1px solid black',
+      border: `1px solid ${appColors.border}`,
       maxHeight: '24vh',
       overflow: 'auto',
       padding: '0em 1em 0em 1em'
@@ -157,7 +181,7 @@ let theme = createTheme({
       textAlign: 'center'
     },
     landing_collections: {
-      border: '1px solid black',
+      border: `1px solid ${appColors.border}`,
       maxHeight: '20vh',
       overflow: 'auto',
       padding: '0em 1em 0em 1em'
@@ -176,31 +200,32 @@ let theme = createTheme({
     landing_page_map_image_wrapper: {
       maxHeight:'180px',
       minWidth: '180px',
-      border:'1px solid grey',
+      border:`1px solid ${appColors.border}`,
       borderRadius:'10px',
       overflow:'clip',
     },
     folder_upload: {
-      background: 'rgb(240, 240, 255)',
+      background: appColors.surfaceTint,
       padding: '1em 2em 1em 2em',
       borderRadius: '15px',
-      backgroundColor: 'rgb(212, 230, 241, 0.95)',
+      backgroundColor: appColors.surfaceTint,
+      color: appColors.text,
     },
     left_sidebar: {
       height: '100%',
       width: '150px',
       maxWidth: '150px',
       minWidth: '150px',
-      background: 'white',
-      borderRight: '1px solid black',
+      background: appColors.surface,
+      borderRight: `1px solid ${appColors.border}`,
       margin: '0px 0px 0px 0px'
     },
     top_sidebar: {
       height: '50px',
       maxWidth: '50px',
       minWidth: '50px',
-      background: 'white',
-      borderBottom: '1px solid black',
+      background: appColors.surface,
+      borderBottom: `1px solid ${appColors.border}`,
       margin: '0px 0px 0px 0px'
     },
     left_sidebar_item: {
@@ -241,8 +266,8 @@ let theme = createTheme({
       width: '200px',
       maxWidth: '200px',
       minWidth: '200px',
-      background: 'white',
-      borderRight: '1px solid black',
+      background: appColors.surface,
+      borderRight: `1px solid ${appColors.border}`,
       margin: '0px 0px 0px 0px'
     },
     species_top_sidebar: {
@@ -250,23 +275,26 @@ let theme = createTheme({
       height: '175px',
       maxHeight: '175px',
       minHeight: '175px',
-      background: 'white',
-      borderRight: '1px solid black',
+      background: appColors.surface,
+      borderRight: `1px solid ${appColors.border}`,
       margin: '0px 0px 0px 0px'
     },
     species_sidebar_item: {
       background: '#E0F0E0',
       border: '1px solid black',
+      borderRadius: 0,
     },
     species_sidebar_item_media: {
       minHeight: '150px',
       maxHeight: '150px',
-      width: '200px'
+      width: '200px',
+      borderRadius: 0,
     },
     species_sidebar_item_media_small: {
       minHeight: '100px',
       maxHeight: '100px',
-      width: '100px'
+      width: '100px',
+      borderRadius: 0,
     },
     screen_disable: {
       position: 'absolute',
@@ -274,7 +302,7 @@ let theme = createTheme({
       top: '0px',
       width: '100vw',
       height: '100vh',
-      backgroundColor: 'rgba(128, 128, 128, 0.65)'
+      backgroundColor: 'rgba(75, 93, 109, 0.65)'
     },
     screen_overlay: {
       position: 'absolute',
@@ -289,7 +317,7 @@ let theme = createTheme({
       top: '0px',
       width: '100vw',
       height: '100vh',
-      backgroundColor:'rgb(0,0,0,0.5)',
+      backgroundColor: appColors.darkOverlay,
     },
     have_messages: {
       '&:after': {

--- a/app/UploadEdit.js
+++ b/app/UploadEdit.js
@@ -1717,7 +1717,7 @@ export default function UploadEdit({selectedUpload, onCancel, searchSetup, uploa
       }
       { pendingMessage && 
             <WorkspaceOverlay>
-              <Typography gutterBottom variant="body2" color="lightgrey">
+              <Typography gutterBottom variant="body2" color="common.white">
                 {pendingMessage}
               </Typography>
               <CircularProgress variant="indeterminate" />

--- a/app/components/CollectionUploadTile.js
+++ b/app/components/CollectionUploadTile.js
@@ -83,10 +83,10 @@ const CollectionUploadTile = React.memo(function CollectionUploadTile({upload, a
   return (
     <Card id={"collection-upload-item-"+upload.name} variant="outlined" 
           data-active={active ? '' : undefined}
-          sx={{minWidth:'100%', backgroundColor:'#D3DEE6', borderRadius:'10px', 
-                '&:hover':{backgroundColor:'rgba(0, 0, 0, 0.25)'},
-                '&[data-active]': {borderColor:'rgba(155, 175, 202, 0.85)',backgroundColor:'#BAC6CD'},
-                '&[data-active]:hover': { backgroundColor:'rgba(0, 0, 0, 0.25)' },
+          sx={{minWidth:'100%', backgroundColor:'#f6f7f8', color:'text.primary', borderColor:'#7f8c96', borderRadius:'6px',
+                '&:hover':{backgroundColor:'#eeeeee'},
+                '&[data-active]': {borderColor:'#4f6274', backgroundColor:'#e8ecef'},
+                '&[data-active]:hover': { backgroundColor:'#e0e4e7' },
               }}
     >
       <CardHeader sx={{ pb: 0 }}
@@ -95,7 +95,7 @@ const CollectionUploadTile = React.memo(function CollectionUploadTile({upload, a
       <CardContent sx={{ pt: 0 }}>
         <Accordion expanded={expanded}
                    onChange={onExpandChange}
-                   sx={{backgroundColor:'#BFCBE1'}}>
+                   sx={{backgroundColor:'#f1f3f5', color:'text.primary'}}>
           <AccordionSummary
             id={'summary-'+upload.name}
             expandIcon={<ExpandMoreIcon />}
@@ -105,7 +105,7 @@ const CollectionUploadTile = React.memo(function CollectionUploadTile({upload, a
               Advanced details
             </Typography>
           </AccordionSummary>
-          <AccordionDetails id={`upload-details-content-${upload.name}`} sx={{backgroundColor:'#C8D2E4'}}>
+          <AccordionDetails id={`upload-details-content-${upload.name}`} sx={{backgroundColor:'#f7f8f9', color:'text.primary'}}>
             <Grid container id={'collection-upload-'+upload.name} direction="column" alignItems="start" justifyContent="start">
               <Grid sx={{padding:'5px 0', width:'100%'}}>
                 <Grid container direction="row" alignItems="start" justifyContent="space-between">

--- a/app/components/WorkspaceOverlay.js
+++ b/app/components/WorkspaceOverlay.js
@@ -4,9 +4,7 @@
 
 import * as React from 'react';
 import Backdrop from '@mui/material/Backdrop';
-import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
-import { useTheme } from '@mui/material/styles';
 
 import PropTypes from 'prop-types';
 
@@ -16,12 +14,10 @@ import PropTypes from 'prop-types';
  * @param {React.ReactNode} [children] The children to display
  */
 export default function WorkspaceOverlay({children}) {
-  const theme = useTheme();
-
   return (
-    <Backdrop open={true} sx={{backgroundColor:'rgb(0,0,0,0.5)', zIndex:11111}} >
-      <Paper sx={{display:'flex', flexDirection:'column', alignItems:'center', backgroundColor:'rgb(0,0,0,0.8)',
-                  border:'1px solid grey', borderRadius:'15px', padding:'25px 10px'}}>
+    <Backdrop open={true} sx={{backgroundColor:'rgba(10, 18, 28, 0.72)', zIndex:11111}} >
+      <Paper sx={{display:'flex', flexDirection:'column', alignItems:'center', backgroundColor:'rgba(14, 23, 33, 0.92)',
+                  color:'common.white', border:'1px solid', borderColor:'divider', borderRadius:'15px', padding:'25px 10px'}}>
           {children}
       </Paper>
     </Backdrop>

--- a/app/page.js
+++ b/app/page.js
@@ -1299,7 +1299,7 @@ export default function Home() {
             >
               <div style={{...theme.palette.login_checking}}>
                 <Grid container direction="column" alignItems="center" justifyContent="center" >
-                    <Typography gutterBottom variant="body2" color="grey">
+                    <Typography gutterBottom variant="body2" color="common.white">
                       Restoring previous session, please wait...
                     </Typography>
                     <CircularProgress variant="indeterminate" />

--- a/app/queries/QueryFilters.js
+++ b/app/queries/QueryFilters.js
@@ -168,12 +168,28 @@ export default function QueryFilters({actionsRef, workingWidth, workingHeight, f
                  }
                />
               <CardContent sx={{position:'relative'}}>
-                <List sx={{backgroundColor:'silver', border:'1px solid grey', borderRadius:'7px', maxHeight:'200px', overflow:'auto'}} >
+                <List sx={{backgroundColor:'background.paper', border:'1px solid', borderColor:'divider', borderRadius:'4px', maxHeight:'200px', overflow:'auto'}} >
                   { filterNames.map((item) => 
                       <ListItem disablePadding key={"query-filter-sel-" + item}>
                           <ListItemButton data-filter={item}
                                           selected={item === filterSelected}
-                                          sx={{padding:'0 8px'}}
+                                          sx={{padding:'0 8px',
+                                               color:'text.primary',
+                                               '&:hover': {
+                                                 backgroundColor:'#eeeeee',
+                                               },
+                                               '&.Mui-selected': {
+                                                 backgroundColor:'#d9d9d9',
+                                               },
+                                               '&.Mui-selected:hover': {
+                                                 backgroundColor:'#d0d0d0',
+                                               },
+                                               '&.Mui-focusVisible': {
+                                                 outline:'2px solid #1565c0',
+                                                 outlineOffset:'-2px',
+                                                 backgroundColor:'#eeeeee',
+                                               },
+                                          }}
                                           onClick={handleFilterSelected}
                                           onDoubleClick={handleFilterDoubleClicked}
                           >

--- a/app/settings/EditUser.js
+++ b/app/settings/EditUser.js
@@ -323,8 +323,9 @@ export default function EditUser({data, onUpdate, onConfirmPassword, onClose}) {
                       },
                     }}
                     />
-               <Button size='small' color='login_button'
-                      sx={{bgcolor: 'background.default', '&:hover':{backgroundColor:'#AEAEAE'}}} endIcon={<LoginIcon />} 
+               <Button size='small' variant='contained' color='login_button'
+                      sx={{boxShadow:'none', '&:hover':{boxShadow:'none'}}}
+                      endIcon={<LoginIcon />} 
                       onClick={handlePasswordConfirm}
               >
                 Confirm

--- a/app/settings/Settings.js
+++ b/app/settings/Settings.js
@@ -374,9 +374,11 @@ export default function Settings({curSettings, onChange, onClose, onLogout, onAd
   return (
     <Grid id='settings-wrapper' ref={settingsWrapperRef}
          sx={{position:'absolute', top:(workingRect.y+20)+'px', right:'20px', zIndex:2000,
-             border:'1px solid grey', backgroundColor:'silver', boxShadow:'2px 3px 3px #bbbbbb'}}
+             border:'1px solid', borderColor:'divider', borderRadius:'4px', backgroundColor:'background.paper',
+             boxShadow:'0 6px 18px rgba(15, 23, 42, 0.22)',
+             overflow:'hidden'}}
     >
-      <Card id="settings-content">
+      <Card id="settings-content" sx={{boxShadow:'none', borderRadius:0}}>
         <CardHeader title="Settings"
                     subheader={<span style={{fontSize:"smaller"}}><span>Customize settings for </span><span style={{fontWeight:'bold'}}>{userName}</span></span>} />
         <CardContent sx={{paddingTop:'0px', paddingBottom:'0px'}}>
@@ -541,8 +543,9 @@ export default function Settings({curSettings, onChange, onClose, onLogout, onAd
                       },
                     }}
                     />
-               <Button size='small' color='login_button'
-                      sx={{bgcolor: 'background.default', '&:hover':{backgroundColor:'#AEAEAE'}}} endIcon={<LoginIcon />} 
+               <Button size='small' variant='contained' color='login_button'
+                      sx={{boxShadow:'none', '&:hover':{boxShadow:'none'}}}
+                      endIcon={<LoginIcon />} 
                       onClick={handleLoginConfirmation}
               >
                 Login

--- a/app/tagging/ImageTile.js
+++ b/app/tagging/ImageTile.js
@@ -8,7 +8,6 @@ import CardContent from '@mui/material/CardContent';
 import CheckCircleOutlinedIcon from '@mui/icons-material/CheckCircleOutlined';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
-import { useTheme } from '@mui/material/styles';
 
 import PropTypes from 'prop-types';
 
@@ -23,8 +22,6 @@ import PropTypes from 'prop-types';
  * @return {object} The UI to render
  */
 export default function ImageTile({name, type, timestamp, species, onClick}) {
-  const theme = useTheme();
-
   if (!species) {
     species = [];
   }
@@ -63,11 +60,40 @@ export default function ImageTile({name, type, timestamp, species, onClick}) {
   }
 
   const haveSpecies = species && species.length > 0;
+  const speciesCount = species.filter((curSpecies) => curSpecies.count > 0).length;
   return (
     <Card id={name} onClick={onClick} variant={haveSpecies?"soft":"outlined"}
-          sx={{minWidth:'200px', '&:hover':{backgroundColor:theme.palette.action.active} }}>
+          sx={{minWidth:'200px',
+               color:'text.primary',
+               backgroundColor: haveSpecies ? '#f1fbf3' : 'background.paper',
+               border:'1px solid',
+               borderColor: haveSpecies ? '#4f8f5b' : 'divider',
+               '&:hover':{
+                 backgroundColor: haveSpecies ? '#e7f6ea' : '#f5f5f5',
+                 color:'text.primary',
+               },
+               '&:hover .MuiTypography-root':{
+                 color:'text.primary',
+               },
+          }}>
       <CardActionArea data-active={haveSpecies ? '' : undefined}
-        sx={{height: '100%', '&[data-active]': {backgroundColor:'rgb(0, 0, 0, 0.35)'} }}
+        sx={{height: '100%',
+             color:'inherit',
+             '& .MuiCardActionArea-focusHighlight': {
+               backgroundColor:'#1565c0',
+             },
+             '&[data-active]': {
+               backgroundColor:'#f1fbf3',
+               color:'text.primary',
+             },
+             '&[data-active]:hover': {
+               backgroundColor:'#e7f6ea',
+               color:'text.primary',
+             },
+             '&[data-active] .MuiTypography-root': {
+               color:'text.primary',
+             },
+        }}
       >
         <CardContent>
           <Grid container spacing={1} alignItems="center" sx={{width:'100%'}}>
@@ -75,11 +101,20 @@ export default function ImageTile({name, type, timestamp, species, onClick}) {
               <Typography variant="body1" sx={{textTransform:'uppercase'}}>
                 {name}
               </Typography>
-              {haveSpecies ? <CheckCircleOutlinedIcon fontSize="small" sx={{color:"#68AB68", marginLeft:'auto'}}/> : null}
+              {haveSpecies ?
+                <Box sx={{display:'flex', alignItems:'center', gap:'4px', marginLeft:'auto',
+                          color:'#256b35', backgroundColor:'#e2f4e5', border:'1px solid #5fa66b',
+                          borderRadius:'999px', padding:'1px 7px'}}>
+                  <CheckCircleOutlinedIcon fontSize="small" sx={{color:'inherit'}}/>
+                  <Typography variant="body3" sx={{color:'inherit', fontWeight:600}}>
+                    Tagged
+                  </Typography>
+                </Box>
+                : null}
             </Grid>
-            {generateImageSvg(haveSpecies ? 'grey':undefined, haveSpecies ? '#68AB68':undefined)}
+            {generateImageSvg(haveSpecies ? '#dbe9dd':undefined, haveSpecies ? '#5fa66b':undefined)}
             <Grid container direction='row' alignItems='center' justifyContent='space-between' sx={{width:'100%'}} >
-              <Typography variant="body1" sx={{border:'1px solid black', borderRadius:'7px', backgroundColor:haveSpecies ? 'dimgrey' : 'silver', padding:'2px 5px' }}>
+              <Typography variant="body1" sx={{border:'1px solid', borderColor:'divider', borderRadius:'7px', backgroundColor:haveSpecies ? '#d8eadf' : '#edf3f7', color:'text.primary', padding:'2px 5px' }}>
                 {type}
               </Typography>
               <Typography variant="body1" sx={{marginLeft:'auto'}} >
@@ -97,6 +132,11 @@ export default function ImageTile({name, type, timestamp, species, onClick}) {
                         </Typography>
                       </Box>
                 )
+              }
+              {haveSpecies && speciesCount === 0 &&
+                <Typography variant="body3" sx={{color:'text.secondary'}}>
+                  Tagged
+                </Typography>
               }
               </Grid>
             </Grid>

--- a/app/tagging/SpeciesSidebarItem.js
+++ b/app/tagging/SpeciesSidebarItem.js
@@ -60,7 +60,7 @@ export default function SpeciesSidebarItem({id, species, size, onKeybindClick, o
   // Render the UI
   return (
     <Grid id={id} draggable='true' display='flex' justifyContent='left' size='grow' spacing={1} sx={cardSx}>
-      <Card sx={{ ...theme.palette.species_sidebar_item }} >
+      <Card sx={{ ...theme.palette.species_sidebar_item, '& .MuiCardMedia-root': { borderRadius: 0 } }} >
         <div style={{position:'relative', display:'inline-block', cursor:'pointer'}}  onClick={(event)=>onZoomClick(event)}>
           <CardMedia
             sx={{...mediaSx}}


### PR DESCRIPTION
This PR makes a focused accessibility pass on frontend color contrast, hover states, and visual clarity without changing app behavior.

Changes include:
- Replaces low-contrast gray MUI background defaults with lighter app surfaces.
- Improves text contrast on loading overlays, selected image cards, upload cards, and collection cards.
- Makes tagged image cards clearer with a stronger completed state and a visible “Tagged” badge.
- Updates login/confirmation buttons to flat blue contained buttons.
- Cleans up the user settings popup surface, border, and shadow.
- Removes rounded corners from species sidebar cards.
- Improves filter chooser hover, selected, and keyboard focus states.
- Restores collection list row colors closer to the previous neutral styling.
- Adds small spacing between collection/upload cards where cards were visually running together.

Validation:
- Ran `pnpm build` successfully.